### PR TITLE
handle userId and shorten error messages

### DIFF
--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/SensitivityAnalysisController.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/SensitivityAnalysisController.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+import static org.gridsuite.sensitivityanalysis.server.service.NotificationService.HEADER_USER_ID;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
@@ -74,8 +75,9 @@ public class SensitivityAnalysisController {
                                                          @Parameter(description = "reportUuid") @RequestParam(name = "reportUuid", required = false) UUID reportUuid,
                                                          @Parameter(description = "reporterId") @RequestParam(name = "reporterId", required = false) String reporterId,
                                                          @Parameter(description = "The type name for the report") @RequestParam(name = "reportType", required = false, defaultValue = "SensitivityAnalysis") String reportType,
-                                                         @RequestBody SensitivityAnalysisInputData sensitivityAnalysisInputData) {
-        SensitivityAnalysisResult result = workerService.run(new SensitivityAnalysisRunContext(networkUuid, variantId, sensitivityAnalysisInputData, null, provider, reportUuid, reporterId, reportType));
+                                                         @RequestBody SensitivityAnalysisInputData sensitivityAnalysisInputData,
+                                                         @RequestHeader(HEADER_USER_ID) String userId) {
+        SensitivityAnalysisResult result = workerService.run(new SensitivityAnalysisRunContext(networkUuid, variantId, sensitivityAnalysisInputData, null, provider, reportUuid, reporterId, reportType, userId));
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
     }
 
@@ -92,8 +94,9 @@ public class SensitivityAnalysisController {
                                            @Parameter(description = "reportUuid") @RequestParam(name = "reportUuid", required = false) UUID reportUuid,
                                            @Parameter(description = "reporterId") @RequestParam(name = "reporterId", required = false) String reporterId,
                                            @Parameter(description = "The type name for the report") @RequestParam(name = "reportType", required = false, defaultValue = "SensitivityAnalysis") String reportType,
-                                           @RequestBody SensitivityAnalysisInputData sensitivityAnalysisInputData) {
-        UUID resultUuid = service.runAndSaveResult(new SensitivityAnalysisRunContext(networkUuid, variantId, sensitivityAnalysisInputData, receiver, provider, reportUuid, reporterId, reportType));
+                                           @RequestBody SensitivityAnalysisInputData sensitivityAnalysisInputData,
+                                           @RequestHeader(HEADER_USER_ID) String userId) {
+        UUID resultUuid = service.runAndSaveResult(new SensitivityAnalysisRunContext(networkUuid, variantId, sensitivityAnalysisInputData, receiver, provider, reportUuid, reporterId, reportType, userId));
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(resultUuid);
     }
 

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/NotificationService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/NotificationService.java
@@ -94,19 +94,15 @@ public class NotificationService {
         publisher.send("publishFailed-out-0", message);
     }
 
-    // the message is shortened before being sent to the study-server.
-    // I keep the beginning and ending, it should make it easier to identify
+    // prevents the message from being too long for rabbitmq
+    // the beginning and ending are both kept, it should make it easier to identify
     public String shortenMessage(String msg) {
         if (msg == null) {
             return msg;
         }
 
-        String shortMsg = msg;
-        if (shortMsg.length() > MSG_MAX_LENGTH) {
-            shortMsg = msg.substring(0, MSG_MAX_LENGTH / 2) +
-                    " ... " +
-                    msg.substring(msg.length() - MSG_MAX_LENGTH / 2, msg.length() - 1);
-        }
-        return shortMsg;
+        return msg.length() > MSG_MAX_LENGTH ?
+                msg.substring(0, MSG_MAX_LENGTH / 2) + " ... " + msg.substring(msg.length() - MSG_MAX_LENGTH / 2, msg.length() - 1)
+                : msg;
     }
 }

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisResultContext.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisResultContext.java
@@ -18,6 +18,8 @@ import org.springframework.messaging.support.MessageBuilder;
 import java.io.UncheckedIOException;
 import java.util.*;
 
+import static org.gridsuite.sensitivityanalysis.server.service.NotificationService.HEADER_USER_ID;
+
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
@@ -63,6 +65,7 @@ public class SensitivityAnalysisResultContext {
 
         String receiver = (String) headers.get("receiver");
         String provider = (String) headers.get("provider");
+        String userId = (String) headers.get(HEADER_USER_ID);
         SensitivityAnalysisInputData sensitivityAnalysisInputData;
         try {
             sensitivityAnalysisInputData = objectMapper.readValue(message.getPayload(), new TypeReference<>() { });
@@ -73,7 +76,7 @@ public class SensitivityAnalysisResultContext {
         String reporterId = headers.containsKey(REPORTER_ID_HEADER) ? (String) headers.get(REPORTER_ID_HEADER) : null;
         String reportType = headers.containsKey(REPORT_TYPE_HEADER) ? (String) headers.get(REPORT_TYPE_HEADER) : null;
         SensitivityAnalysisRunContext runContext = new SensitivityAnalysisRunContext(networkUuid,
-            variantId, sensitivityAnalysisInputData, receiver, provider, reportUuid, reporterId, reportType);
+            variantId, sensitivityAnalysisInputData, receiver, provider, reportUuid, reporterId, reportType, userId);
         return new SensitivityAnalysisResultContext(resultUuid, runContext);
     }
 
@@ -93,6 +96,7 @@ public class SensitivityAnalysisResultContext {
                 .setHeader(REPORT_UUID, runContext.getReportUuid())
                 .setHeader(REPORTER_ID_HEADER, runContext.getReporterId())
                 .setHeader(REPORT_TYPE_HEADER, runContext.getReportType())
+                .setHeader(HEADER_USER_ID, runContext.getUserId())
                 .build();
     }
 }

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisRunContext.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisRunContext.java
@@ -6,6 +6,7 @@
  */
 package org.gridsuite.sensitivityanalysis.server.service;
 
+import lombok.Getter;
 import org.gridsuite.sensitivityanalysis.server.dto.SensitivityAnalysisInputData;
 
 import java.util.Objects;
@@ -14,6 +15,7 @@ import java.util.UUID;
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
+@Getter
 public class SensitivityAnalysisRunContext {
 
     private final UUID networkUuid;
@@ -32,11 +34,14 @@ public class SensitivityAnalysisRunContext {
 
     private final String reporterId;
 
+    private final String userId;
+
     private final String reportType;
 
     public SensitivityAnalysisRunContext(UUID networkUuid, String variantId,
                                          SensitivityAnalysisInputData sensitivityAnalysisInputData,
-                                         String receiver, String provider, UUID reportUuid, String reporterId, String reportType) {
+                                         String receiver, String provider, UUID reportUuid,
+                                         String reporterId, String reportType, String userId) {
         this.networkUuid = Objects.requireNonNull(networkUuid);
         this.variantId = variantId;
         this.sensitivityAnalysisInputData = Objects.requireNonNull(sensitivityAnalysisInputData);
@@ -46,41 +51,6 @@ public class SensitivityAnalysisRunContext {
         this.reportUuid = reportUuid;
         this.reporterId = reporterId;
         this.reportType = reportType;
-    }
-
-    public UUID getNetworkUuid() {
-        return networkUuid;
-    }
-
-    public String getVariantId() {
-        return variantId;
-    }
-
-    public SensitivityAnalysisInputData getSensitivityAnalysisInputData() {
-        return sensitivityAnalysisInputData;
-    }
-
-    public SensitivityAnalysisInputs getSensitivityAnalysisInputs() {
-        return sensitivityAnalysisInputs;
-    }
-
-    public String getReceiver() {
-        return receiver;
-    }
-
-    public String getProvider() {
-        return provider;
-    }
-
-    public UUID getReportUuid() {
-        return reportUuid;
-    }
-
-    public String getReporterId() {
-        return reporterId;
-    }
-
-    public String getReportType() {
-        return reportType;
+        this.userId = userId;
     }
 }

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisWorkerService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisWorkerService.java
@@ -245,7 +245,8 @@ public class SensitivityAnalysisWorkerService {
             } catch (Exception | OutOfMemoryError e) {
                 if (!(e instanceof CancellationException)) {
                     LOGGER.error(FAIL_MESSAGE, e);
-                    notificationService.publishFail(resultContext.getResultUuid(), resultContext.getRunContext().getReceiver(), e.getMessage());
+                    notificationService.publishFail(resultContext.getResultUuid(), resultContext.getRunContext().getReceiver(),
+                            e.getMessage(), resultContext.getRunContext().getUserId());
                     resultRepository.delete(resultContext.getResultUuid());
                     resultRepository.insertStatus(List.of(resultContext.getResultUuid()), SensitivityAnalysisStatus.FAILED.name());
                 }

--- a/src/test/java/org/gridsuite/sensitivityanalysis/server/SensitivityAnalysisControllerTest.java
+++ b/src/test/java/org/gridsuite/sensitivityanalysis/server/SensitivityAnalysisControllerTest.java
@@ -82,6 +82,7 @@ import java.util.stream.Stream;
 import static com.powsybl.network.store.model.NetworkStoreApi.VERSION;
 import static org.gridsuite.sensitivityanalysis.server.service.NotificationService.CANCEL_MESSAGE;
 import static org.gridsuite.sensitivityanalysis.server.service.NotificationService.FAIL_MESSAGE;
+import static org.gridsuite.sensitivityanalysis.server.service.NotificationService.HEADER_USER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -511,6 +512,7 @@ public class SensitivityAnalysisControllerTest {
         MvcResult result = mockMvc.perform(post(
                 "/" + VERSION + "/networks/{networkUuid}/run?reportType=SensitivityAnalysis&variantId=" + VARIANT_3_ID, NETWORK_UUID)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(HEADER_USER_ID, "testUserId")
             .content(SENSITIVITY_INPUT_1))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -522,6 +524,7 @@ public class SensitivityAnalysisControllerTest {
             result = mockMvc.perform(post(
                 "/" + VERSION + "/networks/{networkUuid}/run?reportType=SensitivityAnalysis", NETWORK_UUID)
                 .contentType(MediaType.APPLICATION_JSON)
+                .header(HEADER_USER_ID, "testUserId")
                 .content(sensitivityInput))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -533,6 +536,7 @@ public class SensitivityAnalysisControllerTest {
         result = mockMvc.perform(post(
                 "/" + VERSION + "/networks/{networkUuid}/run?reportType=SensitivityAnalysis&provider=OpenLoadFlow", NETWORK_UUID)
                 .contentType(MediaType.APPLICATION_JSON)
+                .header(HEADER_USER_ID, "testUserId")
                 .content(SENSITIVITY_INPUT_HVDC_DELTA_A))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -545,6 +549,7 @@ public class SensitivityAnalysisControllerTest {
         MvcResult result = mockMvc.perform(post(
                 "/" + VERSION + "/networks/{networkUuid}/run-and-save?reportType=SensitivityAnalysis&receiver=me&variantId=" + VARIANT_2_ID, NETWORK_UUID)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(HEADER_USER_ID, "testUserId")
             .content(SENSITIVITY_INPUT_1))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -708,6 +713,7 @@ public class SensitivityAnalysisControllerTest {
         MvcResult result = mockMvc.perform(post(
                 "/" + VERSION + "/networks/{networkUuid}/run-and-save?reportType=SensitivityAnalysis", NETWORK_UUID)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(HEADER_USER_ID, "testUserId")
             .content(SENSITIVITY_INPUT_1))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -748,6 +754,7 @@ public class SensitivityAnalysisControllerTest {
         mockMvc.perform(post(
             "/" + VERSION + "/networks/{networkUuid}/run-and-save?reportType=SensitivityAnalysis&receiver=me&variantId=" + VARIANT_2_ID, NETWORK_STOP_UUID)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(HEADER_USER_ID, "testUserId")
             .content(SENSITIVITY_INPUT_1))
             .andExpect(status().isOk());
 
@@ -768,6 +775,7 @@ public class SensitivityAnalysisControllerTest {
         MvcResult result = mockMvc.perform(post(
                 "/" + VERSION + "/networks/{networkUuid}/run-and-save?reportType=SensitivityAnalysis&receiver=me&variantId=" + VARIANT_1_ID, NETWORK_ERROR_UUID)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(HEADER_USER_ID, "testUserId")
             .content(SENSITIVITY_INPUT_1))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -791,6 +799,7 @@ public class SensitivityAnalysisControllerTest {
         MvcResult result = mockMvc.perform(post(
                 "/" + VERSION + "/networks/{networkUuid}/run?reportType=SensitivityAnalysis&reportUuid=" + REPORT_UUID + "&reporterId=" + UUID.randomUUID(), NETWORK_UUID)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(HEADER_USER_ID, "testUserId")
             .content(SENSITIVITY_INPUT_1))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/org/gridsuite/sensitivityanalysis/server/dto/SensitivityAnalysisInputDataTest.java
+++ b/src/test/java/org/gridsuite/sensitivityanalysis/server/dto/SensitivityAnalysisInputDataTest.java
@@ -127,7 +127,7 @@ public class SensitivityAnalysisInputDataTest {
             .build();
         ReporterModel reporter = new ReporterModel("a", "b");
         SensitivityAnalysisRunContext context;
-        context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID, inputData, null, null, null, null, null);
+        context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID, inputData, null, null, null, null, null, null);
         inputBuilderService.build(context, NETWORK, reporter);
         Collection<Report> reports;
         reports = reporter.getReports();
@@ -157,7 +157,7 @@ public class SensitivityAnalysisInputDataTest {
                 .contingencies(List.of(new EquipmentsContainer(UUID.randomUUID(), "u10"), new EquipmentsContainer(UUID.randomUUID(), "u11")))
                 .build()))
             .build();
-        context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID, inputData, null, null, null, null, null);
+        context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID, inputData, null, null, null, null, null, null);
         inputBuilderService.build(context, NETWORK, reporter);
         Collection<Report> reports = reporter.getReports();
         assertThat(reports, not(nullValue()));
@@ -177,7 +177,7 @@ public class SensitivityAnalysisInputDataTest {
 
         SensitivityAnalysisInputData inputData = inputBuilder
             .build();
-        context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID, inputData, null, null, null, null, null);
+        context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID, inputData, null, null, null, null, null, null);
         final ReporterModel reporter = new ReporterModel("a", "b");
         var thrown = assertThrows(NullPointerException.class, () -> inputBuilderService.build(context, NETWORK, reporter));
         assertThat(thrown, Matchers.instanceOf(NullPointerException.class));

--- a/src/test/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisServiceTest.java
+++ b/src/test/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisServiceTest.java
@@ -141,7 +141,7 @@ public class SensitivityAnalysisServiceTest {
     @Test
     public void test0() {
         SensitivityAnalysisRunContext context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID,
-                getDummyInputData(), null, null, null, null, null);
+                getDummyInputData(), null, null, null, null, null, null);
         testBasic(true, context);
         testBasic(false, context);
     }
@@ -158,7 +158,7 @@ public class SensitivityAnalysisServiceTest {
                 .loadFlowSpecificParameters(null)
                 .build();
         SensitivityAnalysisRunContext context = new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID,
-                inputData, null, "OpenLoadFlow", null, null, null);
+                inputData, null, "OpenLoadFlow", null, null, null, null);
         testBasic(true, context);
 
         // with non-null LF params
@@ -306,7 +306,7 @@ public class SensitivityAnalysisServiceTest {
 
         UUID gottenResultUuid = analysisService.runAndSaveResult(
             new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID,
-                getDummyInputData(), null, null, null, null, null));
+                getDummyInputData(), null, null, null, null, null, null));
         assertThat(gottenResultUuid, not(nullValue()));
         assertThat(gottenResultUuid, is(resultUuid));
 
@@ -378,7 +378,7 @@ public class SensitivityAnalysisServiceTest {
 
         UUID gottenResultUuid = analysisService.runAndSaveResult(
             new SensitivityAnalysisRunContext(NETWORK_UUID, VARIANT_ID,
-                getDummyInputData(), null, null, null, null, null));
+                getDummyInputData(), null, null, null, null, null, null));
         assertThat(gottenResultUuid, not(nullValue()));
         assertThat(gottenResultUuid, is(resultUuid));
 


### PR DESCRIPTION
1 Bug fix : The full error message is still logged but only a shortened version is sent through rabbitmq (prevents it from crashing).

2. userId is added to the run context and transmitted in the messages (because it is needed in order to display the error messages on the front side)