### PR TITLE
Fix Remove FAILED status and its leak in BDD

### DIFF
--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/dto/SensitivityAnalysisStatus.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/dto/SensitivityAnalysisStatus.java
@@ -12,6 +12,5 @@ package org.gridsuite.sensitivityanalysis.server.dto;
 public enum SensitivityAnalysisStatus {
     NOT_DONE,
     RUNNING,
-    COMPLETED,
-    FAILED
+    COMPLETED
 }

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/dto/nonevacuatedenergy/NonEvacuatedEnergyStatus.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/dto/nonevacuatedenergy/NonEvacuatedEnergyStatus.java
@@ -12,6 +12,5 @@ package org.gridsuite.sensitivityanalysis.server.dto.nonevacuatedenergy;
 public enum NonEvacuatedEnergyStatus {
     NOT_DONE,
     RUNNING,
-    COMPLETED,
-    FAILED
+    COMPLETED
 }

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisWorkerService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisWorkerService.java
@@ -258,7 +258,6 @@ public class SensitivityAnalysisWorkerService {
                     notificationService.publishSensitivityAnalysisFail(resultContext.getResultUuid(), resultContext.getRunContext().getReceiver(),
                             e.getMessage(), resultContext.getRunContext().getUserId());
                     resultRepository.delete(resultContext.getResultUuid());
-                    resultRepository.insertStatus(List.of(resultContext.getResultUuid()), SensitivityAnalysisStatus.FAILED.name());
                 }
             } finally {
                 futures.remove(resultContext.getResultUuid());

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/nonevacuatedenergy/NonEvacuatedEnergyWorkerService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/nonevacuatedenergy/NonEvacuatedEnergyWorkerService.java
@@ -1015,7 +1015,6 @@ public class NonEvacuatedEnergyWorkerService {
                     LOGGER.error(FAIL_MESSAGE, e);
                     notificationService.publishNonEvacuatedEnergyFail(nonEvacuatedEnergyResultContext.getResultUuid(), nonEvacuatedEnergyResultContext.getRunContext().getReceiver(), e.getMessage(), nonEvacuatedEnergyResultContext.getRunContext().getUserId());
                     nonEvacuatedEnergyRepository.delete(nonEvacuatedEnergyResultContext.getResultUuid());
-                    nonEvacuatedEnergyRepository.insertStatus(List.of(nonEvacuatedEnergyResultContext.getResultUuid()), NonEvacuatedEnergyStatus.FAILED.name());
                 }
             } finally {
                 futures.remove(nonEvacuatedEnergyResultContext.getResultUuid());

--- a/src/main/resources/db/changelog/changesets/changelog_20240124T134319Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240124T134319Z.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="sbouzols" id="1701433486877-1">
+        <delete tableName="global_status">
+            <where>result_uuid NOT IN (SELECT result_uuid FROM analysis_result)</where>
+        </delete>
+    </changeSet>
+    <changeSet author="sbouzols" id="1701433486877-2">
+        <delete tableName="non_evacuated_energy_global_status">
+            <where>result_uuid NOT IN (SELECT result_uuid FROM non_evacuated_energy_result)</where>
+        </delete>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20240205T102706Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240205T102706Z.xml
@@ -1,13 +1,13 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <changeSet author="sbouzols" id="1701433486877-1">
+<changeSet author="sbouzols" id="1701433486867-1">
         <delete tableName="global_status">
-            <where>result_uuid NOT IN (SELECT result_uuid FROM analysis_result)</where>
+            <where>result_uuid NOT IN (SELECT result_uuid FROM analysis_result) AND status = 'FAILED'</where>
         </delete>
     </changeSet>
-    <changeSet author="sbouzols" id="1701433486877-2">
+    <changeSet author="sbouzols" id="1701433486867-2">
         <delete tableName="non_evacuated_energy_global_status">
-            <where>result_uuid NOT IN (SELECT result_uuid FROM non_evacuated_energy_result)</where>
+            <where>result_uuid NOT IN (SELECT result_uuid FROM non_evacuated_energy_result) AND status = 'FAILED'</where>
         </delete>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20240205T102706Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240205T102706Z.xml
@@ -2,12 +2,12 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 <changeSet author="sbouzols" id="1701433486867-1">
         <delete tableName="global_status">
-            <where>result_uuid NOT IN (SELECT result_uuid FROM analysis_result) AND status = 'FAILED'</where>
+            <where>status = 'FAILED'</where>
         </delete>
     </changeSet>
     <changeSet author="sbouzols" id="1701433486867-2">
         <delete tableName="non_evacuated_energy_global_status">
-            <where>result_uuid NOT IN (SELECT result_uuid FROM non_evacuated_energy_result) AND status = 'FAILED'</where>
+            <where>status = 'FAILED'</where>
         </delete>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,5 +16,5 @@ databaseChangeLog:
       file: changesets/changelog_20231201T122431Z.xml
       relativeToChangelogFile: true
   - include:
-      file: changesets/changelog_20240124T134319Z.xml
+      file: changesets/changelog_20240205T102706Z.xml
       relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -15,4 +15,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20231201T122431Z.xml
       relativeToChangelogFile: true
-
+  - include:
+      file: changesets/changelog_20240124T134319Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
When Failing (catching an exception) we remove the result in this service and in study-server. 
Then, before this fix we inserted a `FAILED` status, but it was never used and never removed. Kind of a leak in the database.
This fix remove this insertion and add a changeset to remove rows in `global_status` tables not relative to rows in `analysis_result` table to clean previous leaks.

**Test done :** 
mount postgres database
insert manually a fake row in `global_status` table and in `non_evacuated_energy_global_status`
Check if at pod running the liquibase changeset clean those insertions.