### PR TITLE
performance: add an index to improve contingency results deletion

### DIFF
--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/entities/SensitivityResultEntity.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/entities/SensitivityResultEntity.java
@@ -29,7 +29,9 @@ import java.util.UUID;
         @Index(name = "sensitivity_result_analysis_result_factor_index_idx", columnList = "analysis_result_id, factor_index"),
         @Index(name = "sensitivity_result_analysis_result_factor_index_search_idx", columnList = "analysis_result_id, factor_index, function_type, variable_type, function_id, variable_id"),
         // Greatly helps during deletion as it references itself as a foreign key
-        @Index(name = "sensitivity_result_pre_contingency_sensitivity_result_id_idx", columnList = "pre_contingency_sensitivity_result_id")
+        @Index(name = "sensitivity_result_pre_contingency_sensitivity_result_id_idx", columnList = "pre_contingency_sensitivity_result_id"),
+        // Greatly helps during contingency results deletion as it references a foreign key
+        @Index(name = "sensitivity_result_contingency_result_id_idx", columnList = "contingency_id")
     }
 )
 public class SensitivityResultEntity {

--- a/src/main/resources/db/changelog/changesets/changelog_20240408T113947Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240408T113947Z.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="mancinijor (generated)" id="1712576400527-1">
+        <createIndex tableName="sensitivity_result" indexName="sensitivity_result_contingency_result_id_idx">
+            <column name="contingency_id" />
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -27,3 +27,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20240403T121850Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20240408T113947Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
With thousands of contingency results in the same computation it could lead to very long results deletion. Thanks to a new index on the foreign key it solves the issue.