### PR TITLE
Populate element names for result's variation id

### DIFF
--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/dto/SensitivityOfTo.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/dto/SensitivityOfTo.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -26,6 +27,7 @@ import lombok.experimental.SuperBuilder;
 public class SensitivityOfTo {
     @NonNull
     private String funcId;
+    @Setter
     @NonNull
     private String varId;
     private boolean varIsAFilter;

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
@@ -59,14 +59,15 @@ public class DirectoryService {
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         try {
-            return restTemplate.exchange(
+            Map<UUID, String> body = restTemplate.exchange(
                             baseUri + path,
                             HttpMethod.GET,
                             new HttpEntity<>(headers),
                             new ParameterizedTypeReference<Map<UUID, String>>() { }
                     ).getBody();
+            return body != null ? body : Map.of();
 
-        } catch (HttpClientErrorException e) {
+        } catch (RestClientException e) {
             return Map.of();
         }
     }

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.sensitivityanalysis.server.service;
+
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * @author Caroline Jeandat {@literal <caroline.jeandat at rte-france.com>}
+ */
+@Service
+public class DirectoryService {
+    static final String DIRECTORY_API_VERSION = "v1";
+    private static final String DELIMITER = "/";
+    @Setter
+    private String baseUri;
+
+    private final RestTemplate restTemplate;
+
+    public DirectoryService(@Value("${gridsuite.services.directory-server.base-uri:http://directory-server/}") String baseUri, RestTemplate restTemplate) {
+        this.baseUri = baseUri;
+        this.restTemplate = restTemplate;
+    }
+
+    public Map<UUID, String> getElementNames(Set<UUID> elementUuids) {
+        Objects.requireNonNull(elementUuids);
+
+        if (elementUuids.isEmpty()) {
+            return Map.of();
+        }
+
+        URI path = UriComponentsBuilder
+                .fromPath(DELIMITER + DIRECTORY_API_VERSION + "/elements/names")
+                .queryParam("ids", elementUuids)
+                .queryParam("strictMode", "false") // to ignore non existing elements error
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            return restTemplate.exchange(
+                            baseUri + path,
+                            HttpMethod.GET,
+                            new HttpEntity<>(headers),
+                            new ParameterizedTypeReference<Map<UUID, String>>() { }
+                    ).getBody();
+
+        } catch (HttpClientErrorException e) {
+            return Map.of();
+        }
+    }
+}

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryService.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 public class DirectoryService {
     static final String DIRECTORY_API_VERSION = "v1";
     private static final String DELIMITER = "/";
+    public static final String DIRECTORY_API_GET_ELEMENTS_NAMES_ENDPOINT = DELIMITER + DIRECTORY_API_VERSION + "/elements/names";
     @Setter
     private String baseUri;
 
@@ -49,7 +50,7 @@ public class DirectoryService {
         }
 
         URI path = UriComponentsBuilder
-                .fromPath(DELIMITER + DIRECTORY_API_VERSION + "/elements/names")
+                .fromPath(DIRECTORY_API_GET_ELEMENTS_NAMES_ENDPOINT)
                 .queryParam("ids", elementUuids)
                 .queryParam("strictMode", "false") // to ignore non existing elements error
                 .build()

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisInputBuilderService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisInputBuilderService.java
@@ -20,9 +20,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.gridsuite.sensitivityanalysis.server.util.ResultUtils.formatVariationId;
+import static org.gridsuite.sensitivityanalysis.server.util.ResultUtils.joinToStringIds;
 
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
@@ -133,10 +139,6 @@ public class SensitivityAnalysisInputBuilderService {
         return listIdentifiableAttributes.stream();
     }
 
-    private String joinToStringIds(List<UUID> filterIds) {
-        return "[" + filterIds.stream().map(UUID::toString).collect(Collectors.joining(", ")) + "]";
-    }
-
     private Stream<IdentifiableAttributes> getMonitoredIdentifiables(SensitivityAnalysisRunContext context, Network network, List<UUID> filterIds, List<IdentifiableType> equipmentsTypesAllowed, ReportNode reporter) {
         String idsString = joinToStringIds(filterIds);
         List<IdentifiableAttributes> listIdentAttributes = goGetIdentifiables(filterIds, context.getNetworkUuid(), context.getVariantId(), reporter);
@@ -211,8 +213,7 @@ public class SensitivityAnalysisInputBuilderService {
         List<SensitivityVariableSet> result = new ArrayList<>();
         List<IdentifiableAttributes> monitoredVariablesLists = getIdentifiables(context, filterIds, variablesTypesAllowed, reporter)
                 .toList();
-        String idsString = joinToStringIds(filterIds);
-        Stream<Pair<String, List<IdentifiableAttributes>>> variablesLists = Stream.of(Pair.of(idsString, monitoredVariablesLists))
+        Stream<Pair<List<UUID>, List<IdentifiableAttributes>>> variablesLists = Stream.of(Pair.of(filterIds, monitoredVariablesLists))
                 .filter(list -> !list.getRight().isEmpty());
 
         variablesLists.forEach(variablesList -> {
@@ -257,7 +258,7 @@ public class SensitivityAnalysisInputBuilderService {
                         break;
                 }
             }
-            result.add(new SensitivityVariableSet(variablesList.getLeft() + " (" + distributionType.name() + ")", variables));
+            result.add(new SensitivityVariableSet(formatVariationId(variablesList.getLeft(), distributionType.name()), variables));
         });
 
         return result;

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
@@ -172,7 +172,6 @@ public class SensitivityAnalysisService extends AbstractComputationService<Sensi
             throw new ComputationException(RESULT_NOT_FOUND, "The sensitivity analysis result '" + resultUuid + "' does not exist");
         }
 
-
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
             zipOutputStream.putNextEntry(new ZipEntry("sensitivity_result.csv"));

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
@@ -50,8 +50,6 @@ import static org.gridsuite.sensitivityanalysis.server.util.ResultUtils.resolveF
 @Service
 public class SensitivityAnalysisService extends AbstractComputationService<SensitivityAnalysisRunContext, SensitivityAnalysisResultService, SensitivityAnalysisStatus> {
 
-    public static final String UUID_REGEX = "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi";
-
     public static final char CSV_DELIMITER_FR = ';';
     public static final char CSV_DELIMITER_EN = ',';
     public static final char CSV_QUOTE_ESCAPE = '"';

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
@@ -9,14 +9,14 @@ package org.gridsuite.sensitivityanalysis.server.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.sensitivity.SensitivityAnalysisProvider;
 import com.univocity.parsers.csv.CsvFormat;
-import org.gridsuite.computation.error.ComputationException;
+import com.univocity.parsers.csv.CsvWriter;
+import com.univocity.parsers.csv.CsvWriterSettings;
 import org.gridsuite.computation.dto.GlobalFilter;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
+import org.gridsuite.computation.error.ComputationException;
 import org.gridsuite.computation.service.AbstractComputationService;
 import org.gridsuite.computation.service.NotificationService;
 import org.gridsuite.computation.service.UuidGeneratorService;
-import com.univocity.parsers.csv.CsvWriter;
-import com.univocity.parsers.csv.CsvWriterSettings;
 import org.gridsuite.sensitivityanalysis.server.dto.*;
 import org.gridsuite.sensitivityanalysis.server.dto.parameters.FactorCount;
 import org.gridsuite.sensitivityanalysis.server.dto.resultselector.ResultTab;
@@ -34,17 +34,23 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static org.gridsuite.computation.error.ComputationBusinessErrorCode.INVALID_EXPORT_PARAMS;
 import static org.gridsuite.computation.error.ComputationBusinessErrorCode.RESULT_NOT_FOUND;
+import static org.gridsuite.sensitivityanalysis.server.util.ResultUtils.extractUuidsFromVariationId;
+import static org.gridsuite.sensitivityanalysis.server.util.ResultUtils.resolveForVariationId;
 
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 @Service
 public class SensitivityAnalysisService extends AbstractComputationService<SensitivityAnalysisRunContext, SensitivityAnalysisResultService, SensitivityAnalysisStatus> {
+
+    public static final String UUID_REGEX = "/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi";
 
     public static final char CSV_DELIMITER_FR = ';';
     public static final char CSV_DELIMITER_EN = ',';
@@ -55,6 +61,7 @@ public class SensitivityAnalysisService extends AbstractComputationService<Sensi
     private final SensitivityAnalysisFactorCountService sensitivityAnalysisFactorCountService;
 
     private final FilterService filterService;
+    private final DirectoryService directoryService;
 
     public SensitivityAnalysisService(@Value("${sensitivity-analysis.default-provider}") String defaultProvider,
                                       SensitivityAnalysisResultService resultService,
@@ -62,10 +69,12 @@ public class SensitivityAnalysisService extends AbstractComputationService<Sensi
                                       NotificationService notificationService,
                                       SensitivityAnalysisFactorCountService sensitivityAnalysisFactorCountService,
                                       FilterService filterService,
+                                      DirectoryService directoryService,
                                       ObjectMapper objectMapper) {
         super(notificationService, resultService, objectMapper, uuidGeneratorService, defaultProvider);
         this.sensitivityAnalysisFactorCountService = sensitivityAnalysisFactorCountService;
         this.filterService = filterService;
+        this.directoryService = directoryService;
     }
 
     @Override
@@ -101,7 +110,28 @@ public class SensitivityAnalysisService extends AbstractComputationService<Sensi
             Optional<ResourceFilterDTO> resourceGlobalFilters = filterService.getResourceFilter(networkUuid, variantId, globalFilter);
             resourceGlobalFilters.ifPresent(allResourceFilters::add);
         }
-        return resultService.getRunResult(resultUuid, selector, allResourceFilters);
+        SensitivityRunQueryResult result = resultService.getRunResult(resultUuid, selector, allResourceFilters);
+        if (result != null) {
+            populateResultWithElementNames(result);
+        }
+        return result;
+    }
+
+    /**
+     * Populates the SensitivityRunQueryResult by replacing UUIDs in sensitivity varId with
+     * corresponding element names.
+     */
+    private void populateResultWithElementNames(SensitivityRunQueryResult result) {
+        // collect all UUIDs from VarId
+        Stream<String> varIdStream = result.getSensitivities().stream().map(SensitivityOfTo::getVarId);
+        Set<UUID> allUUIDs = varIdStream.flatMap(varId -> extractUuidsFromVariationId(varId).stream()).collect(Collectors.toSet());
+
+        // fetch all element names for all UUIDs
+        Map<UUID, String> nameByUuid = directoryService.getElementNames(allUUIDs);
+
+        // replace UUIDs in sensitivity varId with corresponding element names
+        result.getSensitivities().forEach(sensitivity ->
+            sensitivity.setVarId(resolveForVariationId(sensitivity.getVarId(), nameByUuid)));
     }
 
     public SensitivityResultFilterOptions getSensitivityResultOptions(UUID resultUuid, ResultsSelector selector) {
@@ -141,6 +171,8 @@ public class SensitivityAnalysisService extends AbstractComputationService<Sensi
         if (result == null) {
             throw new ComputationException(RESULT_NOT_FOUND, "The sensitivity analysis result '" + resultUuid + "' does not exist");
         }
+
+        populateResultWithElementNames(result);
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/service/SensitivityAnalysisService.java
@@ -172,7 +172,6 @@ public class SensitivityAnalysisService extends AbstractComputationService<Sensi
             throw new ComputationException(RESULT_NOT_FOUND, "The sensitivity analysis result '" + resultUuid + "' does not exist");
         }
 
-        populateResultWithElementNames(result);
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtils.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtils.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.gridsuite.sensitivityanalysis.server.util;
+
+import lombok.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @author Thang PHAM <quyet-thang.pham at rte-france.com>
+ */
+public final class ResultUtils {
+
+    private ResultUtils() {
+        throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    private static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+    public static List<UUID> extractUuidsFromVariationId(@NonNull String varId) {
+        List<UUID> uuids = new ArrayList<>();
+        Matcher matcher = Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE).matcher(varId);
+        while (matcher.find()) {
+            uuids.add(UUID.fromString(matcher.group()));
+        }
+        return uuids;
+    }
+
+    public static String resolveForVariationId(@NonNull String varId, Map<UUID, String> nameByUuid) {
+        return Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE)
+                .matcher(varId)
+                .replaceAll(match -> nameByUuid.getOrDefault(UUID.fromString(match.group()), match.group()));
+    }
+
+    public static String formatVariationId(List<UUID> uuids, String distributionType) {
+        return joinToStringIds(uuids) + " (" + distributionType + ")";
+    }
+
+    public static String joinToStringIds(List<UUID> uuids) {
+        return "[" + uuids.stream().map(UUID::toString).collect(Collectors.joining(", ")) + "]";
+    }
+}

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtils.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtils.java
@@ -27,6 +27,7 @@ public final class ResultUtils {
     }
 
     private static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+    public static final Pattern UUID_PATTERN = Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE);
 
     /**
      * Extracts all UUIDs from the given variation ID string based on a predefined format.
@@ -37,7 +38,7 @@ public final class ResultUtils {
      */
     public static List<UUID> extractUuidsFromVariationId(@NonNull String varId) {
         List<UUID> uuids = new ArrayList<>();
-        Matcher matcher = Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE).matcher(varId);
+        Matcher matcher = UUID_PATTERN.matcher(varId);
         while (matcher.find()) {
             uuids.add(UUID.fromString(matcher.group()));
         }
@@ -53,7 +54,7 @@ public final class ResultUtils {
      * @return the resolved variation ID string with UUIDs replaced by their corresponding names where applicable
      */
     public static String resolveForVariationId(@NonNull String varId, Map<UUID, String> nameByUuid) {
-        return Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE)
+        return UUID_PATTERN
                 .matcher(varId)
                 .replaceAll(match -> nameByUuid.getOrDefault(UUID.fromString(match.group()), match.group()));
     }

--- a/src/main/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtils.java
+++ b/src/main/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtils.java
@@ -7,7 +7,7 @@
 
 package org.gridsuite.sensitivityanalysis.server.util;
 
-import lombok.NonNull;
+import org.springframework.lang.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +28,13 @@ public final class ResultUtils {
 
     private static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
 
+    /**
+     * Extracts all UUIDs from the given variation ID string based on a predefined format.
+     * "[uuid1, uuid2] (REGULAR)" — finds all UUIDs inside brackets.
+     *
+     * @param varId the variation ID string containing possible UUIDs, must not be null
+     * @return a list of UUIDs extracted from the provided variation ID string; if no UUIDs are found, returns an empty list
+     */
     public static List<UUID> extractUuidsFromVariationId(@NonNull String varId) {
         List<UUID> uuids = new ArrayList<>();
         Matcher matcher = Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE).matcher(varId);
@@ -37,16 +44,38 @@ public final class ResultUtils {
         return uuids;
     }
 
+    /**
+     * Resolves a variation ID string by replacing all UUIDs found within the string with their corresponding names
+     * from the provided map. If a UUID has no corresponding name in the map, it is left unchanged in the string.
+     *
+     * @param varId the variation ID string containing possible UUIDs, must not be null
+     * @param nameByUuid a map containing UUID-to-name mappings used to replace UUIDs in the variation ID string; must not be null
+     * @return the resolved variation ID string with UUIDs replaced by their corresponding names where applicable
+     */
     public static String resolveForVariationId(@NonNull String varId, Map<UUID, String> nameByUuid) {
         return Pattern.compile(UUID_REGEX, Pattern.CASE_INSENSITIVE)
                 .matcher(varId)
                 .replaceAll(match -> nameByUuid.getOrDefault(UUID.fromString(match.group()), match.group()));
     }
 
+    /**
+     * Formats a variation ID string by concatenating a formatted list of UUIDs and a distribution type.
+     *
+     * @param uuids a list of UUIDs to be included in the variation ID, must not be null
+     * @param distributionType the distribution type to append to the variation ID, must not be null
+     * @return a string representing the formatted variation ID, which includes the concatenated UUIDs and the distribution type
+     */
     public static String formatVariationId(List<UUID> uuids, String distributionType) {
         return joinToStringIds(uuids) + " (" + distributionType + ")";
     }
 
+    /**
+     * Joins a list of UUIDs into a single string where each UUID is separated by a comma
+     * and the entire string is enclosed in square brackets.
+     *
+     * @param uuids the list of UUIDs to be joined into a string must not be null
+     * @return a string representation of the list of UUIDs, formatted as "[uuid1, uuid2, ...]"
+     */
     public static String joinToStringIds(List<UUID> uuids) {
         return "[" + uuids.stream().map(UUID::toString).collect(Collectors.joining(", ")) + "]";
     }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -24,3 +24,5 @@ gridsuite:
       base-uri: http://localhost:5028
     loadflow-server:
       base-uri: http://localhost:5008
+    directory-server:
+      base-uri: http://localhost:5026

--- a/src/test/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryServiceTest.java
+++ b/src/test/java/org/gridsuite/sensitivityanalysis/server/service/DirectoryServiceTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.sensitivityanalysis.server.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.gridsuite.sensitivityanalysis.server.service.DirectoryService.DIRECTORY_API_GET_ELEMENTS_NAMES_ENDPOINT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Caroline Jeandat {@literal <caroline.jeandat at rte-france.com>}
+ */
+@AutoConfigureMockMvc
+@SpringBootTest
+class DirectoryServiceTest {
+
+    private WireMockServer wireMockServer;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private DirectoryService directoryService;
+
+    private static final UUID ELEMENT_UUID_1 = UUID.fromString("3f7c9e2a-8b41-4d6a-a1f3-9c5b72e8d4af");
+    private static final String ELEMENT_NAME_1 = "name1";
+    private static final UUID ELEMENT_UUID_2 = UUID.fromString("b8a4f2c1-6d3e-4a9b-92f7-1e5c8d7a3b60");
+    private static final String ELEMENT_NAME_2 = "name2";
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMockServer.start();
+        ReflectionTestUtils.setField(directoryService, "baseUri", wireMockServer.baseUrl());
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void getElementNamesWithNullElementUuidsTest() {
+        assertThrows(NullPointerException.class,
+                () -> directoryService.getElementNames(null));
+    }
+
+    @Test
+    void getElementNamesWithEmptyElementUuidsTest() {
+        assertEquals(Map.of(), directoryService.getElementNames(Set.of()));
+    }
+
+    @Test
+    void getElementNamesTest() throws JsonProcessingException {
+        Map<UUID, String> elementNameByUuid = Map.of(
+                ELEMENT_UUID_1, ELEMENT_NAME_1,
+                ELEMENT_UUID_2, ELEMENT_NAME_2
+        );
+        wireMockServer.stubFor(WireMock.get(WireMock.urlPathEqualTo(DIRECTORY_API_GET_ELEMENTS_NAMES_ENDPOINT))
+                .withQueryParam("ids", WireMock.equalTo(ELEMENT_UUID_1.toString()))
+                .withQueryParam("ids", WireMock.equalTo(ELEMENT_UUID_2.toString()))
+                .withQueryParam("strictMode", WireMock.equalTo("false"))
+                .willReturn(WireMock.ok().withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).withBody(objectMapper.writeValueAsString(elementNameByUuid))));
+
+        assertEquals(elementNameByUuid, directoryService.getElementNames(Set.of(ELEMENT_UUID_1, ELEMENT_UUID_2)));
+    }
+}

--- a/src/test/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtilsTest.java
+++ b/src/test/java/org/gridsuite/sensitivityanalysis/server/util/ResultUtilsTest.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.sensitivityanalysis.server.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+/**
+ * @author Thang PHAM <quyet-thang.pham at rte-france.com>
+ */
+class ResultUtilsTest {
+
+    // --- extractUuidsFromVariationId ---
+
+    @Test
+    void extractUuidsFromVariationIdSingleUuid() {
+        UUID uuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        String varId = "[" + uuid + "] (REGULAR)";
+
+        List<UUID> result = ResultUtils.extractUuidsFromVariationId(varId);
+
+        assertThat(result).containsExactly(uuid);
+    }
+
+    @Test
+    void extractUuidsFromVariationIdMultipleUuids() {
+        UUID uuid1 = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID uuid2 = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        String varId = "[" + uuid1 + ", " + uuid2 + "] (REGULAR)";
+
+        List<UUID> result = ResultUtils.extractUuidsFromVariationId(varId);
+
+        assertThat(result).containsExactly(uuid1, uuid2);
+    }
+
+    @Test
+    void extractUuidsFromVariationIdNoUuid() {
+        String varId = "[Name1, Name2] (REGULAR)";
+
+        List<UUID> result = ResultUtils.extractUuidsFromVariationId(varId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void extractUuidsFromVariationIdEmptyString() {
+        List<UUID> result = ResultUtils.extractUuidsFromVariationId("");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void extractUuidsFromVariationIdUuidCaseInsensitive() {
+        String varId = "[AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE] (PROPORTIONAL)";
+
+        List<UUID> result = ResultUtils.extractUuidsFromVariationId(varId);
+
+        assertThat(result).containsExactly(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"));
+    }
+
+    @Test
+    void extractUuidsFromVariationIdNullThrowsNullPointerException() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> ResultUtils.extractUuidsFromVariationId(null));
+    }
+
+    // --- resolveForVariationId ---
+
+    @Test
+    void resolveForVariationIdSingleUuidResolved() {
+        UUID uuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        String varId = "[" + uuid + "] (REGULAR)";
+        Map<UUID, String> nameByUuid = Map.of(uuid, "Name_1");
+
+        String result = ResultUtils.resolveForVariationId(varId, nameByUuid);
+
+        assertThat(result).isEqualTo("[Name_1] (REGULAR)");
+    }
+
+    @Test
+    void resolveForVariationIdMultipleUuidsAllResolved() {
+        UUID uuid1 = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID uuid2 = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        String varId = "[" + uuid1 + ", " + uuid2 + "] (PROPORTIONAL)";
+        Map<UUID, String> nameByUuid = Map.of(uuid1, "Name_1", uuid2, "Name_2");
+
+        String result = ResultUtils.resolveForVariationId(varId, nameByUuid);
+
+        assertThat(result).isEqualTo("[Name_1, Name_2] (PROPORTIONAL)");
+    }
+
+    @Test
+    void resolveForVariationIdUuidNotInMapKeptAsIs() {
+        UUID uuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        String varId = "[" + uuid + "] (REGULAR)";
+        Map<UUID, String> nameByUuid = Map.of();
+
+        String result = ResultUtils.resolveForVariationId(varId, nameByUuid);
+
+        assertThat(result).isEqualTo(varId);
+    }
+
+    @Test
+    void resolveForVariationIdPartiallyResolved() {
+        UUID uuid1 = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID uuid2 = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        String varId = "[" + uuid1 + ", " + uuid2 + "] (REGULAR)";
+        Map<UUID, String> nameByUuid = Map.of(uuid1, "Name_1");
+
+        String result = ResultUtils.resolveForVariationId(varId, nameByUuid);
+
+        assertThat(result).isEqualTo("[Name_1, " + uuid2 + "] (REGULAR)");
+    }
+
+    @Test
+    void resolveForVariationIdNoUuidInString() {
+        String varId = "[Name1] (REGULAR)";
+        Map<UUID, String> nameByUuid = Map.of();
+
+        String result = ResultUtils.resolveForVariationId(varId, nameByUuid);
+
+        assertThat(result).isEqualTo(varId);
+    }
+
+    @Test
+    void resolveForVariationIdEmptyString() {
+        String result = ResultUtils.resolveForVariationId("", Map.of());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void resolveForVariationIdNullThrowsNullPointerException() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> ResultUtils.resolveForVariationId(null, Map.of()));
+    }
+
+    // --- formatVariationId ---
+
+    @Test
+    void formatVariationIdSingleUuid() {
+        UUID uuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
+
+        String result = ResultUtils.formatVariationId(List.of(uuid), "REGULAR");
+
+        assertThat(result).isEqualTo("[11111111-2222-3333-4444-555555555555] (REGULAR)");
+    }
+
+    @Test
+    void formatVariationIdMultipleUuids() {
+        UUID uuid1 = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID uuid2 = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+        String result = ResultUtils.formatVariationId(List.of(uuid1, uuid2), "PROPORTIONAL");
+
+        assertThat(result).isEqualTo("[11111111-2222-3333-4444-555555555555, aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee] (PROPORTIONAL)");
+    }
+
+    @Test
+    void formatVariationIdEmptyList() {
+        String result = ResultUtils.formatVariationId(List.of(), "REGULAR");
+
+        assertThat(result).isEqualTo("[] (REGULAR)");
+    }
+
+    // --- joinToStringIds ---
+
+    @Test
+    void joinToStringIdsSingleUuid() {
+        UUID uuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
+
+        String result = ResultUtils.joinToStringIds(List.of(uuid));
+
+        assertThat(result).isEqualTo("[11111111-2222-3333-4444-555555555555]");
+    }
+
+    @Test
+    void joinToStringIdsMultipleUuids() {
+        UUID uuid1 = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID uuid2 = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+        String result = ResultUtils.joinToStringIds(List.of(uuid1, uuid2));
+
+        assertThat(result).isEqualTo("[11111111-2222-3333-4444-555555555555, aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee]");
+    }
+
+    @Test
+    void joinToStringIdsEmptyList() {
+        String result = ResultUtils.joinToStringIds(List.of());
+
+        assertThat(result).isEqualTo("[]");
+    }
+
+    // --- roundtrip: formatVariationId -> extractUuidsFromVariationId ---
+
+    @Test
+    void roundtripFormatThenExtract() {
+        UUID uuid1 = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID uuid2 = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+        String formatted = ResultUtils.formatVariationId(List.of(uuid1, uuid2), "REGULAR");
+        List<UUID> extracted = ResultUtils.extractUuidsFromVariationId(formatted);
+
+        assertThat(extracted).containsExactly(uuid1, uuid2);
+    }
+
+    // --- roundtrip: formatVariationId -> resolveForVariationId ---
+
+    @Test
+    void roundtripFormatThenResolve() {
+        UUID uuid1 = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        UUID uuid2 = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        Map<UUID, String> nameByUuid = Map.of(uuid1, "Name_1", uuid2, "Name_2");
+
+        String formatted = ResultUtils.formatVariationId(List.of(uuid1, uuid2), "REGULAR");
+        String resolved = ResultUtils.resolveForVariationId(formatted, nameByUuid);
+
+        assertThat(resolved).isEqualTo("[Name_1, Name_2] (REGULAR)");
+    }
+}


### PR DESCRIPTION
## PR Summary
Back to the solution which uses the directory client service to resolve element names for the variationId in the result

[uuid1, uuid2] (REGULAR) => [name1, name2] (REGULAR)



